### PR TITLE
Use channel instead color functions.

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,11 +104,11 @@ function toJSON(value) {
         return {
             type: 'SassColor'
             , value: {
-                r: value.red
-                , g: value.green
-                , b: value.blue
+                r: value.channel("red")
+                , g: value.channel("green")
+                , b: value.channel("blue")
                 , a: value.alpha
-                , hex: color.rgb(value.red, value.green, value.blue).hex().toLowerCase()
+                , hex: color.rgb(value.channel("red"), value.channel("green"), value.channel("blue")).hex().toLowerCase()
             }
         };
     }


### PR DESCRIPTION
Hello. Good morning. Thank you very much for your module.

I've been getting this warning message for a while now when compiling using your module:

    Deprecation Warning [color-4-api]: blue is deprecated, use `channel` instead.
    More info: https://sass-lang.com/d/color-4-api

I modified your code to use the **channel** function instead of the **red**, **blue**, and **green** color functions, and the warning message disappeared.

If you have any other concerns, I'll be happy to answer your questions.